### PR TITLE
Repo config

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,25 @@
+# copier-ProjectScaffolding Open Source Code of Conduct
+
+## Principles
+These principles guide our data, product, and process decisions, architecture, and approach.
+
+- Open means transparent and participatory.
+- We take a modular and modern approach to software development.
+- We build open-source software and open-source process.
+- We value ease of implementation.
+- Fostering community includes building capacity and making our software and processes accessible to participants with diverse backgrounds and skillsets.
+- Data (and data science) is as important as software and process. We build open data sets where possible.
+- We strive for transparency for algorithms and places we might be introducing bias.
+
+## Community Guidelines
+Information on contributing to this repository is available in our [Contributing file](CONTRIBUTING.md).
+
+When participating in copier-ProjectScaffolding open source community conversations and spaces, we ask individuals to follow the following guidelines:
+
+- Embrace a culture of learning, and educate each other. We are all entering this conversation from different starting points and with different backgrounds. There are no dumb questions.
+- Take space and give space. We strive to create an equitable environment in which all are welcome and able to participate. We hope individuals feel comfortable voicing their opinions and providing contributions and will do our best to recognize and make space for individuals who may be struggling to find space here. Likewise, we expect individuals to recognize when they are taking up significant space and take a step back to allow room for others.
+- Be respectful.
+- Default to positive. Assume others' contributions are legitimate and valuable and that they are made with good intention.
+
+## Acknowledgements
+This Community Guidelines was adapted from the [United States Digital Service](https://usds.gov) [Justice40](https://thejustice40.com) open source [repository](https://github.com/usds/justice40-tool).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# copier-ProjectScaffolding Open Source Code of Conduct
+# MARL_MNIST Open Source Code of Conduct
 
 ## Principles
 These principles guide our data, product, and process decisions, architecture, and approach.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contribution Guidelines
+
+## Contributor Code of Conduct
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of the level of experience, gender, gender identity, expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+[Project maintainers](MAINTAINERS.md) have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the [project maintainers](MAINTAINERS.md).
+
+## General information
+For specific proposals, please provide them as [pull requests](https://github.com/coreinfrastructure/best-practices-badge/pulls) or [issues](https://github.com/coreinfrastructure/best-practices-badge/issues) via our [GitHub site](https://github.com/varun646/MARL_MNIST).
+
+### Pull requests and different branches recommended
+Pull requests are preferred, since they are specific. For more about how to create a pull request, see https://help.github.com/articles/using-pull-requests/.
+
+We recommend creating different branches for different (logical) changes, and creating a pull request into the `main` branch when you're done. See the GitHub documentation on [creating branches](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/) and [using pull requests](https://help.github.com/articles/using-pull-requests/).
+
+### How we handle proposals
+We use GitHub to track proposed changes via its [issue tracker](https://github.com/coreinfrastructure/best-practices-badge/issues) and [pull requests](https://github.com/coreinfrastructure/best-practices-badge/pulls). Specific changes are proposed using those mechanisms. Issues are assigned to an individual, who works and then marks it complete. If there are questions or objections, the conversation of that issue or pull request is used to resolve it.
+
+### We are proactive
+In general we try to be proactive to detect and eliminate mistakes and vulnerabilities as soon as possible, and to reduce their impact when they do happen. We use a defensive design and coding style to reduce the likelihood of mistakes, a variety of tools that try to detect mistakes early, and an automatic test suite with significant coverage. We also release the software as open source software so others can review it.
+
+Since early detection and impact reduction can never be perfect, we also try to detect and repair problems during deployment as quickly as possible. This is especially true for security issues; see our [security information](#vulnerability-reporting-security-issues) for more information.
+
+## Vulnerability reporting (security issues)
+Please privately report vulnerabilities you find so we can fix them!
+
+See [SECURITY.md](SECURITY.md) for information on how to privately report vulnerabilities.
+
+## Acknowledgements
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,14 @@
+# Maintainers
+
+This page lists all active maintainers of this repository. If you were a maintainer and would like to add your name to the Emeritus list, please send us a pull request.
+
+See [Code of Conduct](CODE_OF_CONDUCT.md) and [Contributing](CONTRIBUTING.md) for general contribution guidelines.
+
+## Current Maintainers
+| Maintainer | GitHub ID | Affiliation |
+| --- | --- | --- |
+| Varun Narayan | @varun646 | |
+
+## Emeritus
+| Maintainer | GitHub ID | Affiliation |
+| --- | --- | --- |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security
+
+If you find a significant vulnerability, or evidence of one, please report it privately.
+
+We prefer that you use the [GitHub mechanism for privately reporting a vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability). Under the [main repository's security tab](https://github.com/gt-sse-center/copier-ProjectScaffolding/security), in the left sidebar, under "Reporting", click "Advisories", click the "New draft security advisory" button to open the advisory form.
+[issues](https://github.com/coreinfrastructure/best-practices-badge/issues) via our [GitHub site](https://github.com/varun646/MARL_MNIST).
+
+We will gladly give credit to anyone who reports a vulnerability so that we can fix it. If you want to remain anonymous or pseudonymous instead, please let us know that; we will gladly respect your wishes.
+
+We gladly welcome patches to fix such vulnerabilities! See [CONTRIBUTING.md](CONTRIBUTING.md) for information about contributions.


### PR DESCRIPTION
add maintainers, security, and code of conduct markdowns. Taken from gt-sse-center/copier-Project-Scaffolding